### PR TITLE
issue/14 – Add the 'order-details' tab to the list for active tab consideration.

### DIFF
--- a/affiliatewp-order-details-for-affiliates.php
+++ b/affiliatewp-order-details-for-affiliates.php
@@ -181,6 +181,11 @@ final class AffiliateWP_Order_Details_For_Affiliates {
 
 		// Add template folder to hold the customer table
 		add_filter( 'affwp_template_paths', array( $this, 'get_theme_template_paths' ) );
+
+		// Add to the tabs list for 1.8.1 (fails silently if the hook doesn't exist).
+		add_filter( 'affwp_affiliate_area_tabs', function( $tabs ) {
+			return array_merge( $tabs, array( 'order-details' ) );
+		} );
 	}
 
 	/**


### PR DESCRIPTION
Issue: #14

In 1.8.1+, the 'order-details' tab needs to be in the tabs list for consideration as a the 'active tab' and thus be able to load the template contents.