### PR TITLE
issue/57 - Add support to WooCommerce Sequential Order Numbers

### DIFF
--- a/includes/class-order-details.php
+++ b/includes/class-order-details.php
@@ -273,21 +273,12 @@ class AffiliateWP_Order_Details_For_Affiliates_Order_Details {
 				if ( $info == 'order_number' ) {
 
 					if ( affiliatewp_order_details_for_affiliates()->woocommerce_is_300() ) {
-						$order_id = $order->get_id();
+						$order_id = $order->get_order_number();
 					} else {
 						$order_id = $order->id;
 					}
 
-					$seq_order_number = get_post_meta( $order_id, '_order_number', true );
-
-					// sequential order numbers compatibility
-					if ( $seq_order_number && class_exists( 'WC_Seq_Order_Number_Pro' ) ) {
-						$order_number = $seq_order_number;
-					} else {
-						$order_number = $referral->reference;
-					}
-
-					return $is_allowed['order_number'] ? $order_number : '';
+					return $is_allowed['order_number'] ? $order_id : '';
 
 				}
 


### PR DESCRIPTION
<!--- Please prefix your PR description above with the issue number: issue/### – PR Description -->

Issue #57 

<!--- Please complete and check off all of the following items prior to submitting for review -->
**Housekeeping**

* [x] Issue number has been linked below the description
* [x] Branch name follows the `issue/###` or `release/###` format
* [x] PR title is prefixed with the branch name (issue/### - Title)

**Proposed changes**

* [x] Code has been tested with no errors
* [x] Code meets stated minimum requirements
* [x] Code should (usually) not contain unrelated changes
* [x] Code style (including docs) and organization is generally consistent with the rest of the codebase
* [x] Before and after screenshots have been posted to document visual changes
* [x] Clear steps for testing the PR have been posted (as needed)

**Implemented changes**
Use `get_order_number`function to get the correct order number, so that if a plugin like "Sequential Order Number for WooCommerce" is used, the changed order number is used.